### PR TITLE
Ajustes nos desenhos de imagem

### DIFF
--- a/engine/include/canvas.h
+++ b/engine/include/canvas.h
@@ -49,7 +49,8 @@ public:
     void draw(const Circle& circle) const;
     void draw(const Circle& circle, const Color& color);
 
-    void draw(const Image *image, int x = 0, int y = 0, int w = 0, int h = 0) const;
+    void draw(const Image *image, int x = 0, int y = 0) const;
+    void draw(const Image *image, Rect rect_clip, int x = 0, int y = 0) const;
 
     void fill(const Rect& rect) const;
     void fill(const Rect& rect, const Color& color);

--- a/engine/include/canvas.h
+++ b/engine/include/canvas.h
@@ -65,9 +65,13 @@ public:
 
     SDL_Renderer * renderer() const;
 
+    void set_scale(const double scale);
+    double scale() const;
+
 private:
     SDL_Renderer *m_renderer;
     int m_w, m_h;
+    double m_scale;
     Font_Manager *m_font;
     Color m_color;
 

--- a/engine/include/canvas.h
+++ b/engine/include/canvas.h
@@ -49,7 +49,7 @@ public:
     void draw(const Circle& circle) const;
     void draw(const Circle& circle, const Color& color);
 
-    void draw(const Image *image, int x = 0, int y = 0) const;
+    void draw(const Image *image, int x = 0, int y = 0, int w = 0, int h = 0) const;
 
     void fill(const Rect& rect) const;
     void fill(const Rect& rect, const Color& color);

--- a/engine/include/game.h
+++ b/engine/include/game.h
@@ -19,7 +19,7 @@ using std::string;
 
 class Environment;
 
-class Game : public SystemEventListener, KeyboardEventListener
+class Game : public SystemEventListener, public KeyboardEventListener
 {
 public:
     Game(const string& id);

--- a/engine/include/image.h
+++ b/engine/include/image.h
@@ -24,6 +24,8 @@ public:
 
     int w() const;
     int h() const;
+    Uint8 alpha() const;
+    void set_alpha(const Uint8 alpha);
 
     static Image * from_file(const string& path) throw (Exception);
 
@@ -34,6 +36,7 @@ private:
 
     SDL_Texture *m_texture;
     int m_w, m_h;
+    Uint8 m_alpha;
 };
 
 #endif

--- a/engine/include/level.h
+++ b/engine/include/level.h
@@ -9,6 +9,7 @@
 #define LEVEL_H
 
 #include "object.h"
+#include "environment.h"
 
 #include <string>
 
@@ -25,6 +26,7 @@ public:
 protected:
     string m_next;
     bool m_done;
+    Environment * env;
 };
 
 #endif

--- a/engine/include/rect.h
+++ b/engine/include/rect.h
@@ -26,7 +26,7 @@ public:
     void set(double x, double y);
     void set_dimensions(double w, double h);
 
-private:
+protected:
     double m_x, m_y;
     double m_w, m_h;
 };

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -251,9 +251,9 @@ Canvas::fill_circle_points(int cx, int cy, int x, int y) const
 }
 
 void
-Canvas::draw(const Image *image, int x, int y) const
+Canvas::draw(const Image *image, int x, int y, int w, int h) const
 {
-    SDL_Rect clip {0, 0, image->w(), image->h() };
+    SDL_Rect clip {w, h, image->w(), image->h() };
     SDL_Rect dest {x, y, image->w(), image->h() };
 
     SDL_RenderCopy(m_renderer, image->texture(), &clip, &dest);

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -14,7 +14,7 @@
 #include "image.h"
 
 Canvas::Canvas(SDL_Renderer *renderer, int w, int h)
-    : m_renderer(renderer), m_w(w), m_h(h)
+    : m_renderer(renderer), m_w(w), m_h(h), m_scale(1)
 {
     set_color(Color::WHITE);
 }
@@ -253,8 +253,10 @@ Canvas::fill_circle_points(int cx, int cy, int x, int y) const
 void
 Canvas::draw(const Image *image, int x, int y, int w, int h) const
 {
+    int dest_w = image->w() * m_scale;
+    int dest_h = image->h() * m_scale;
     SDL_Rect clip {w, h, image->w(), image->h() };
-    SDL_Rect dest {x, y, image->w(), image->h() };
+    SDL_Rect dest {x, y, dest_w, dest_h };
 
     SDL_RenderCopy(m_renderer, image->texture(), &clip, &dest);
 }
@@ -290,4 +292,16 @@ Canvas::draw_message(const string message, const Rect rect, const Color& color)
     {
         throw Exception(SDL_GetError());
     }
+}
+
+void
+Canvas::set_scale(const double scale)
+{
+    m_scale *= scale;
+}
+
+double
+Canvas::scale() const
+{
+    return m_scale;
 }

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -251,15 +251,26 @@ Canvas::fill_circle_points(int cx, int cy, int x, int y) const
 }
 
 void
-Canvas::draw(const Image *image, int x, int y, int w, int h) const
+Canvas::draw(const Image *image, Rect rect_clip, int x, int y) const
 {
-    int dest_w = image->w() * m_scale;
-    int dest_h = image->h() * m_scale;
-    SDL_Rect clip {w, h, image->w(), image->h() };
+    int dest_w = rect_clip.w() * m_scale;
+    int dest_h = rect_clip.h() * m_scale;
+    SDL_Rect clip {(int)rect_clip.x(), (int)rect_clip.y(), (int)rect_clip.w(), (int)rect_clip.h() };
     SDL_Rect dest {x, y, dest_w, dest_h };
 
     SDL_RenderCopy(m_renderer, image->texture(), &clip, &dest);
 }
+
+void
+Canvas::draw(const Image *image, int x, int y) const
+{
+    int dest_w = image->w() * m_scale;
+    int dest_h = image->h() * m_scale;
+    SDL_Rect dest {x, y, dest_w, dest_h };
+
+    SDL_RenderCopy(m_renderer, image->texture(), nullptr, &dest);
+}
+
 
 SDL_Renderer *
 Canvas::renderer() const

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -40,6 +40,18 @@ Image::h() const
     return m_h;
 }
 
+Uint8
+Image::alpha() const
+{
+    return m_alpha;
+}
+
+void
+Image::set_alpha(const Uint8 alpha)
+{
+    m_alpha = alpha;
+}
+
 Image *
 Image::from_file(const string& path) throw (Exception)
 {


### PR DESCRIPTION
Nós criamos uma escala para conseguirmos aumentar e diminuir a resolução da tela e rederizar as imagens corretamente, nos métodos draw para imagem separamos em dois, um que tenha clip e outro não, no caso do método com clip ele já recebe o retângulo com o tamanho e posição corretos para fazer o corte na imagem!
