### PR TITLE
scopo protected no level e conserto da posição do dispache de eventos

### DIFF
--- a/engine/include/level.h
+++ b/engine/include/level.h
@@ -26,7 +26,7 @@ public:
     void finish();
     void set_next(const string& next);
 
-private:
+protected:
     string m_next;
     bool m_done;
     Environment * env;

--- a/engine/src/game.cpp
+++ b/engine/src/game.cpp
@@ -59,6 +59,7 @@ Game::run()
     while (m_level and not m_done)
     {
         unsigned long now = update_timestep();
+        env->events_manager->dispatch_pending_events();
 
         m_level->update(now);
         m_level->draw();
@@ -72,8 +73,6 @@ Game::run()
             delete m_level;
             m_level = load_level(next);
         }
-        
-        env->events_manager->dispatch_pending_events();
     }
 }
 


### PR DESCRIPTION
Coloquei o escopo das variáveis de Level para protected para que os filhos enxerguem e voltei o dispache de eventos pra posição original, realmente não fazia sentido o que eu tinha feito!
