### PR TITLE
Mudança do escopo protected na classe Level

### DIFF
--- a/engine/include/core/level.h
+++ b/engine/include/core/level.h
@@ -26,10 +26,9 @@ public:
     void finish();
     void set_next(const string& next);
 
-protected:
+private:
     string m_next;
     bool m_done;
-    Environment * env;
 };
 
 #endif


### PR DESCRIPTION
Mudei o escopo para privado para que os filhos usem apenas os métodos de Level, e apaguei a variável não utlizada env.
