### PR TITLE
Ajustes relacionados a escala

### DIFF
--- a/engine/include/core/canvas.h
+++ b/engine/include/core/canvas.h
@@ -35,13 +35,11 @@ public:
 
     int w() const;
     int h() const;
-    double scale() const;
     const Color& color() const;
     shared_ptr<Font> font() const;
     BlendMode blend_mode() const;
 
     void set_resolution(int w, int h);
-    void set_scale(const double scale);
     void set_color(const Color& color);
     void set_font(shared_ptr<Font>& font);
     void set_blend_mode(BlendMode mode);
@@ -85,7 +83,6 @@ public:
 private:
     SDL_Renderer *m_renderer;
     int m_w, m_h;
-    double m_scale;
     Color m_color;
     shared_ptr<Font> m_font;
     BlendMode m_blend_mode;

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -17,7 +17,7 @@
 #include "core/environment.h"
 
 Canvas::Canvas(SDL_Renderer *renderer, int w, int h)
-    : m_renderer(renderer), m_w(w), m_h(h), m_scale(1), m_blend_mode(NONE)
+    : m_renderer(renderer), m_w(w), m_h(h), m_blend_mode(NONE)
 {
     set_color(Color::WHITE);
     m_bitmap = SDL_CreateRGBSurface(0, w, h, 32, 0, 0, 0, 0);
@@ -360,7 +360,11 @@ Canvas::draw(const Texture *texture, Rect clip, double x, double y) const
     SDL_Rect dest { dest_x, dest_y, dest_w, dest_h };
 
     SDL_Texture *image = static_cast<SDL_Texture *>(texture->data());
-    SDL_RenderCopy(m_renderer, image, &orig, &dest);
+
+    if (dest_w == orig_w and dest_h == orig_h)
+        SDL_RenderCopy(m_renderer, image, nullptr, &dest);
+    else
+        SDL_RenderCopy(m_renderer, image, &orig, &dest);
 }
 
 SDL_Renderer *
@@ -408,18 +412,6 @@ Canvas::draw(const string& text, double x, double y, const Color& color) const
     SDL_RenderCopy(m_renderer, texture, NULL, &dest);
 
     SDL_DestroyTexture(texture);
-}
-
-void
-Canvas::set_scale(const double scale)
-{
-    m_scale = scale;
-}
-
-double
-Canvas::scale() const
-{
-    return m_scale;
 }
 
 Texture *

--- a/engine/src/texture.cpp
+++ b/engine/src/texture.cpp
@@ -11,6 +11,8 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
+#include <iostream>
+using namespace std;
 
 class Texture::Impl
 {
@@ -35,8 +37,21 @@ public:
 
     void scale(double k)
     {
-        m_w *= k;
-        m_h *= k;
+        m_w = resolution().first * k;
+        m_h = resolution().second * k;
+    }
+
+    pair<int, int> resolution() const
+    {
+        int w, h;
+        int rc = SDL_QueryTexture(m_texture, nullptr, nullptr, &w, &h);
+
+        if (rc)
+        {
+            throw Exception(SDL_GetError());
+        }
+
+        return make_pair(w, h);
     }
 
 private:

--- a/engine/src/video.cpp
+++ b/engine/src/video.cpp
@@ -109,7 +109,6 @@ Video::set_resolution(int w, int h, double scale) throw (Exception)
         }
 
         m_canvas->set_resolution(w, h);
-//        m_canvas->set_scale(scale);
         m_camera->set_dimensions(w, h);
 
         Environment *env = Environment::get_instance();


### PR DESCRIPTION
Olá Edson, fiz alguns ajustes com relação a escala. 

Primeiro coloquei uma condição no método draw que verifica se o tamanho do retângulo de corte é igual ao retângulo com a área para o desenho, isso se fez necessário no seguinte exemplo: Com uma imagem de tamanho 1024X768 na resolução em 800X600 ele estava desenhando a imagem na área correta, porém, fazia o corte para esse tamanho também, com as condições que coloquei o corte não será feito no caso citado.

Segundo, o método scale na textura estava sempre atualizando o m_w e m_h da imagem quando a escala é 0.78125, por exemplo, cada momento que carregava o level a mesma ia diminuindo, substitui para pegar de fato o tamanho real da imagem que corrige o problema de alteração do m_w e m_h
