### PR TITLE
Atualização da escala

### DIFF
--- a/engine/include/core/canvas.h
+++ b/engine/include/core/canvas.h
@@ -61,7 +61,7 @@ public:
 
     void draw(const Texture *texture, double x = 0, double y = 0) const;
     void draw(const Texture *texture, Rect clip, double x = 0,
-        double y = 0) const;
+        double y = 0, double w = 0, double h = 0) const;
 
     void draw(const string& text, double x = 0, double y = 0,
         const Color& color = Color::WHITE) const;

--- a/engine/include/core/environment.h
+++ b/engine/include/core/environment.h
@@ -34,6 +34,8 @@ public:
     AudioManagerMusic *music;
     AudioManagerSfx *sfx;
 
+    string m_settings_path;
+
 private:
     Environment();
     void init() throw (Exception);

--- a/engine/include/core/game.h
+++ b/engine/include/core/game.h
@@ -36,7 +36,7 @@ public:
     bool on_event(const KeyboardEvent& event);
 
 protected:
-    string m_id, m_settings;
+    string m_id;
     Level *m_level;
     bool m_done;
     Environment *env;

--- a/engine/include/core/texture.h
+++ b/engine/include/core/texture.h
@@ -12,8 +12,10 @@
 
 #include <string>
 #include <memory>
+#include <iostream>
 
 using std::string;
+using std::pair;
 using std::unique_ptr;
 
 class Texture
@@ -29,6 +31,7 @@ public:
     static Texture * from_file(const string& path) throw (Exception);
 
     void scale(double k);
+	pair<int, int> size() const;    
 
 private:
     class Impl;

--- a/engine/include/core/texture.h
+++ b/engine/include/core/texture.h
@@ -13,8 +13,8 @@
 #include <string>
 #include <memory>
 
-using std::string;
 using std::pair;
+using std::string;
 using std::unique_ptr;
 
 class Texture
@@ -30,7 +30,7 @@ public:
     static Texture * from_file(const string& path) throw (Exception);
 
     void scale(double k);
-	pair<int, int> size() const;    
+    pair<int, int> size() const;
 
 private:
     class Impl;

--- a/engine/include/core/texture.h
+++ b/engine/include/core/texture.h
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <memory>
-#include <iostream>
 
 using std::string;
 using std::pair;

--- a/engine/src/animation.cpp
+++ b/engine/src/animation.cpp
@@ -90,7 +90,7 @@ Animation::draw(double x, double y)
               };
 
     Environment *env = Environment::get_instance();
-    env->canvas->draw(m_impl->texture.get(), clip, x, y);
+    env->canvas->draw(m_impl->texture.get(), clip, x, y, clip.w(), clip.h());
 }
 
 double

--- a/engine/src/bitmap.cpp
+++ b/engine/src/bitmap.cpp
@@ -191,4 +191,3 @@ Bitmap::fill(const Rect& r, Uint32 color)
 {
     m_impl->fill(r, color);
 }
-

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -29,7 +29,7 @@ Canvas::Canvas(SDL_Renderer *renderer, int w, int h)
 
 Canvas::~Canvas()
 {
-    free(m_bitmap);
+    SDL_FreeSurface(m_bitmap);
     SDL_DestroyTexture(m_texture);
 }
 
@@ -74,10 +74,14 @@ void
 Canvas::set_resolution(int w, int h)
 {
     if (m_bitmap)
+    {
         SDL_FreeSurface(m_bitmap);
+    }
 
     if (m_texture)
+    {
         SDL_DestroyTexture(m_texture);
+    }
 
     m_bitmap = SDL_CreateRGBSurface(0, w, h, 32, 0, 0, 0, 0);
     m_texture = SDL_CreateTexture(m_renderer, SDL_PIXELFORMAT_ARGB8888,

--- a/engine/src/canvas.cpp
+++ b/engine/src/canvas.cpp
@@ -336,13 +336,13 @@ Canvas::draw(const Texture *texture, double x, double y) const
         return;
     }
 
-    Rect clip { 0, 0, (double) texture->w(), (double) texture->h() };
+    Rect clip { 0, 0, (double) texture->size().first, (double) texture->size().second };
 
     draw(texture, clip, x, y);
 }
 
 void
-Canvas::draw(const Texture *texture, Rect clip, double x, double y) const
+Canvas::draw(const Texture *texture, Rect clip, double x, double y, double w, double h) const
 {
     Environment *env = Environment::get_instance();
 
@@ -353,18 +353,15 @@ Canvas::draw(const Texture *texture, Rect clip, double x, double y) const
 
     int dest_x = (int) x - env->camera->x();
     int dest_y = (int) y - env->camera->y();
-    int dest_w = (int) clip.w();
-    int dest_h = (int) clip.h();
+    int dest_w = (w ? (int) w : (int) texture->w());
+    int dest_h = (h ? (int) h : (int) texture->h());
 
     SDL_Rect orig { orig_x, orig_y, orig_w, orig_h };
     SDL_Rect dest { dest_x, dest_y, dest_w, dest_h };
 
     SDL_Texture *image = static_cast<SDL_Texture *>(texture->data());
 
-    if (dest_w == orig_w and dest_h == orig_h)
-        SDL_RenderCopy(m_renderer, image, nullptr, &dest);
-    else
-        SDL_RenderCopy(m_renderer, image, &orig, &dest);
+    SDL_RenderCopy(m_renderer, image, &orig, &dest);
 }
 
 SDL_Renderer *

--- a/engine/src/environment.cpp
+++ b/engine/src/environment.cpp
@@ -14,7 +14,7 @@ static Environment *env = nullptr;
 Environment::Environment()
     : video(nullptr), resources_manager(nullptr), events_manager(nullptr),
     audio_manager(nullptr), canvas(nullptr), camera(nullptr), music(nullptr),
-    sfx(nullptr)
+    sfx(nullptr), m_settings_path("")
 {
 }
 

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -6,6 +6,8 @@
  * Licença: LGPL. Sem copyright.
  */
 #include "core/font.h"
+#include "core/environment.h"
+#include "core/settings.h"
 
 class Font::Impl
 {
@@ -40,7 +42,11 @@ public:
 
     void set_size(int size)
     {
-        change_size(size);
+        Environment *env = Environment::get_instance();
+        shared_ptr<Settings> settings = env->resources_manager->get_settings(env->m_settings_path);
+        double k = settings->read<double>("Game", "scale", 1);
+
+        change_size(size * k);
     }
 
     void set_style(Style style)

--- a/engine/src/game.cpp
+++ b/engine/src/game.cpp
@@ -16,7 +16,7 @@
 #include <SDL2/SDL_mixer.h>
 
 Game::Game(const string& id)
-    : m_id(id), m_settings(""), m_level(nullptr), m_done(false)
+    : m_id(id), m_level(nullptr), m_done(false)
 {
     env = Environment::get_instance();
 
@@ -58,7 +58,7 @@ Game::init(const string& title, int w, int h, double scale, bool fullscreen,
 void
 Game::init(const string& path) throw (Exception)
 {
-    m_settings = path;
+    env->m_settings_path = path;
 
     shared_ptr<Settings> settings = env->resources_manager->get_settings(path);
 

--- a/engine/src/texture.cpp
+++ b/engine/src/texture.cpp
@@ -13,7 +13,7 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 
- using std::make_pair;
+using std::make_pair;
 
 class Texture::Impl
 {
@@ -128,7 +128,7 @@ Texture::from_file(const string& path) throw (Exception)
 void
 Texture::scale(double k)
 {
-    m_impl->scale(k);    
+    m_impl->scale(k);
 }
 
 pair<int, int>

--- a/engine/src/texture.cpp
+++ b/engine/src/texture.cpp
@@ -8,6 +8,7 @@
 #include "core/texture.h"
 #include "core/exception.h"
 #include "core/environment.h"
+#include "core/settings.h"
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
@@ -21,6 +22,12 @@ public:
         : m_w(w), m_h(h)
     {
         m_texture = static_cast<SDL_Texture *>(data);
+
+        Environment *env = Environment::get_instance();
+        shared_ptr<Settings> settings = env->resources_manager->get_settings(env->m_settings_path);
+        double k = settings->read<double>("Game", "scale", 1);
+
+        scale(k);
     }
 
     ~Impl()

--- a/engine/src/texture.cpp
+++ b/engine/src/texture.cpp
@@ -11,8 +11,8 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
-#include <iostream>
-using namespace std;
+
+ using std::make_pair;
 
 class Texture::Impl
 {
@@ -37,11 +37,11 @@ public:
 
     void scale(double k)
     {
-        m_w = resolution().first * k;
-        m_h = resolution().second * k;
+        m_w = size().first * k;
+        m_h = size().second * k;
     }
 
-    pair<int, int> resolution() const
+    pair<int, int> size() const
     {
         int w, h;
         int rc = SDL_QueryTexture(m_texture, nullptr, nullptr, &w, &h);
@@ -122,4 +122,10 @@ void
 Texture::scale(double k)
 {
     m_impl->scale(k);    
+}
+
+pair<int, int>
+Texture::size() const
+{
+    return m_impl->size();
 }


### PR DESCRIPTION
Professor,
Mudamos a variável m_settings do game para o environment, assim é possível acessar essa variável e pegar o valor da escala no construtor da textura. Isso foi necessário, pois assim as novas instâncias da textura já são criadas com o tamanho certo.
Nós atualizamos o draw da textura pra para fazer o clip de acordo com o tamanho real da imagem e não de acordo com o tamanho do objeto (que este está multiplicado pela escala).
Acrescentamos os parâmetros "w" e "h" no método de draw, pois o tamanho da imagem desenhada deve ser diferente em casos de sprites por exemplo.
